### PR TITLE
Restore compatibility with Python 2.6

### DIFF
--- a/spyral/core.py
+++ b/spyral/core.py
@@ -37,6 +37,9 @@ def _get_executing_scene():
     """
     for frame, _, _, _, _, _ in inspect.stack():
         args, _, _, local_data = inspect.getargvalues(frame)
+        if sys.version_info[0:2]==(2,6):
+            # workaround for Python 2.6, see http://bugs.python.org/issue4092
+            args = inspect.ArgInfo(*args)
         if len(args) > 0 and args[0] == 'self':
             obj = local_data['self']
             if isinstance(obj, spyral.Scene):


### PR DESCRIPTION
Needed to work on XO with Fedora 11 / Python 2.6 - as still found on the field in Peru.

See:
https://github.com/icarito/peru-learns-english/commit/87e82040705ee50b6e37f999b29ea2dbc990d1c8
